### PR TITLE
Add support for specifying apns id in push headers

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -61,6 +61,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     private static final AsciiString APNS_TOPIC_HEADER = new AsciiString("apns-topic");
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
+    private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
 
     private static final long STREAM_ID_RESET_THRESHOLD = Integer.MAX_VALUE - 1;
 
@@ -232,6 +233,10 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         if (pushNotification.getTopic() != null) {
             headers.add(APNS_TOPIC_HEADER, pushNotification.getTopic());
+        }
+
+        if (pushNotification.getApnsId() != null) {
+            headers.add(APNS_ID_HEADER, pushNotification.getApnsId().toString());
         }
 
         return headers;

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
@@ -21,6 +21,7 @@
 package com.relayrides.pushy.apns;
 
 import java.util.Date;
+import java.util.UUID;
 
 import com.relayrides.pushy.apns.util.ApnsPayloadBuilder;
 
@@ -99,4 +100,13 @@ public interface ApnsPushNotification {
      * @since 0.8.1
      */
     String getCollapseId();
+
+    /**
+     * Returns an optional identifier for this notification that is specified in the apns-id header when sending.
+     *
+     * @return an apns identifier for this notification; may be {@code null}
+     *
+     * @since 0.9.4
+     */
+    UUID getApnsId();
 }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
@@ -22,6 +22,7 @@ package com.relayrides.pushy.apns.util;
 
 import java.util.Date;
 import java.util.Objects;
+import java.util.UUID;
 
 import com.relayrides.pushy.apns.ApnsPushNotification;
 import com.relayrides.pushy.apns.DeliveryPriority;
@@ -41,6 +42,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
     private final DeliveryPriority priority;
     private final String topic;
     private final String collapseId;
+    private final UUID apnsId;
 
     /**
      * Constructs a new push notification with the given token, topic, and payload. No expiration time is set for the
@@ -55,7 +57,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @see DeliveryPriority#IMMEDIATE
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload) {
-        this(token, topic, payload, null, DeliveryPriority.IMMEDIATE, null);
+        this(token, topic, payload, null, DeliveryPriority.IMMEDIATE, null, null);
     }
     /**
      * Constructs a new push notification with the given token, topic, payload, and expiration time. An "immediate"
@@ -71,7 +73,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @see DeliveryPriority#IMMEDIATE
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime) {
-        this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE, null);
+        this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE, null, null);
     }
 
     /**
@@ -86,23 +88,37 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @param priority the priority with which this notification should be delivered to the receiving device
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority) {
-        this(token, topic, payload, invalidationTime, priority, null);
+        this(token, topic, payload, invalidationTime, priority, null, null);
     }
 
     /**
      * Constructs a new push notification with the given token, topic, payload, delivery expiration time, delivery
      * priority, and "collapse identifier."
-     *
-     * @param token the device token to which this push notification should be delivered; must not be {@code null}
+     *  @param token the device token to which this push notification should be delivered; must not be {@code null}
      * @param topic the topic to which this notification should be sent; must not be {@code null}
      * @param payload the payload to include in this push notification; must not be {@code null}
      * @param invalidationTime the time at which Apple's servers should stop trying to deliver this message; if
      * {@code null}, no delivery attempts beyond the first will be made
      * @param priority the priority with which this notification should be delivered to the receiving device
      * @param collapseId the "collapse identifier" for this notification, which allows it to supersede or be superseded
-     * by other notifications with the same identifier
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority, final String collapseId) {
+        this(token, topic, payload, invalidationTime, priority, collapseId, null);
+    }
+
+    /**
+     * Constructs a new push notification with the given token, topic, payload, delivery expiration time, delivery
+     * priority, and "collapse identifier."
+     *  @param token the device token to which this push notification should be delivered; must not be {@code null}
+     * @param topic the topic to which this notification should be sent; must not be {@code null}
+     * @param payload the payload to include in this push notification; must not be {@code null}
+     * @param invalidationTime the time at which Apple's servers should stop trying to deliver this message; if
+     * {@code null}, no delivery attempts beyond the first will be made
+     * @param priority the priority with which this notification should be delivered to the receiving device
+     * @param collapseId the "collapse identifier" for this notification, which allows it to supersede or be superseded
+     * @param apnsId the apns id header for this notification
+     */
+    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority, final String collapseId, final UUID apnsId) {
         Objects.requireNonNull(token, "Destination device token must not be null.");
         Objects.requireNonNull(topic, "Destination topic must not be null.");
         Objects.requireNonNull(payload, "Payload must not be null.");
@@ -113,6 +129,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         this.priority = priority;
         this.topic = topic;
         this.collapseId = collapseId;
+        this.apnsId = apnsId;
     }
 
     /**
@@ -176,9 +193,19 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         return this.collapseId;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
+    /**
+     * Returns the "APNS ID" for this push notification, which is set as an http header if present
+     *
+     * @return the "APNS ID" for this push notification
      */
+    @Override
+    public UUID getApnsId() {
+        return apnsId;
+    }
+
+    /* (non-Javadoc)
+         * @see java.lang.Object#hashCode()
+         */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -189,6 +216,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         result = prime * result + ((this.token == null) ? 0 : this.token.hashCode());
         result = prime * result + ((this.topic == null) ? 0 : this.topic.hashCode());
         result = prime * result + ((this.collapseId == null) ? 0 : this.collapseId.hashCode());
+        result = prime * result + ((this.apnsId == null) ? 0 : this.apnsId.hashCode());
         return result;
     }
 
@@ -245,6 +273,13 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         } else if (!this.collapseId.equals(other.collapseId)) {
             return false;
         }
+        if (this.apnsId == null) {
+            if (other.apnsId != null) {
+                return false;
+            }
+        } else if (!this.apnsId.equals(other.apnsId)) {
+            return false;
+        }
         return true;
     }
 
@@ -266,6 +301,8 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         builder.append(this.topic);
         builder.append(", apns-collapse-id=");
         builder.append(this.collapseId);
+        builder.append(", apns-id=");
+        builder.append(this.apnsId);
         builder.append("]");
         return builder.toString();
     }

--- a/pushy/src/test/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotificationTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotificationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.util.Date;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -26,6 +27,7 @@ public class SimpleApnsPushNotificationTest {
         assertNull(pushNotification.getExpiration());
         assertEquals(DeliveryPriority.IMMEDIATE, pushNotification.getPriority());
         assertNull(pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
     }
 
     @Test(expected = NullPointerException.class)
@@ -59,6 +61,7 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(DeliveryPriority.IMMEDIATE, pushNotification.getPriority());
         assertNull(pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
     }
 
     @Test
@@ -78,6 +81,7 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
         assertNull(pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
     }
 
     @Test
@@ -98,5 +102,28 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
         assertEquals(collapseId, pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
+    }
+
+    @Test
+    public void testSimpleApnsPushNotificationTokenTopicPayloadExpirationPriorityCollapseIdApnsId() {
+        final String token = "test-token";
+        final String topic = "test-topic";
+        final String payload = "{\"test\": true}";
+        final Date expiration = new Date();
+        final DeliveryPriority priority = DeliveryPriority.CONSERVE_POWER;
+        final String collapseId = "test-collapse-id";
+        final UUID apnsId = UUID.randomUUID();
+
+        final SimpleApnsPushNotification pushNotification =
+                new SimpleApnsPushNotification(token, topic, payload, expiration, priority, collapseId, apnsId);
+
+        assertEquals(token, pushNotification.getToken());
+        assertEquals(topic, pushNotification.getTopic());
+        assertEquals(payload, pushNotification.getPayload());
+        assertEquals(expiration, pushNotification.getExpiration());
+        assertEquals(priority, pushNotification.getPriority());
+        assertEquals(collapseId, pushNotification.getCollapseId());
+        assertEquals(apnsId, pushNotification.getApnsId());
     }
 }


### PR DESCRIPTION
Adds `getApnsId()` to the ApnsPushNotification interface.
Sets `apns-id` header on requests if `getApnsId()` returns a non-null
value.