### PR TITLE
Add back client busy exceptions to pushy client

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -170,6 +170,7 @@ public class ApnsClient {
 
         this.bootstrap.channel(SocketChannelClassUtil.getSocketChannelClass(this.bootstrap.config().group()));
         this.bootstrap.option(ChannelOption.TCP_NODELAY, true);
+        this.bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
         this.bootstrap.handler(new ChannelInitializer<SocketChannel>() {
 
             @Override

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -148,6 +148,7 @@ public class ApnsClient {
     public static final int DEFAULT_PING_IDLE_TIME_MILLIS = 60_000;
 
     private static final ClientNotConnectedException NOT_CONNECTED_EXCEPTION = new ClientNotConnectedException();
+    private static final ClientBusyException CLIENT_BUSY_EXCEPTION = new ClientBusyException();
 
     private static final long INITIAL_RECONNECT_DELAY_SECONDS = 1; // second
     private static final long MAX_RECONNECT_DELAY_SECONDS = 60; // seconds
@@ -549,6 +550,10 @@ public class ApnsClient {
         final ChannelPromise connectionReadyPromise = this.connectionReadyPromise;
 
         if (connectionReadyPromise != null && connectionReadyPromise.isSuccess() && connectionReadyPromise.channel().isActive()) {
+            if (!connectionReadyPromise.channel().isWritable()) {
+                return new FailedFuture<>(GlobalEventExecutor.INSTANCE, CLIENT_BUSY_EXCEPTION);
+            }
+
             final Channel channel = connectionReadyPromise.channel();
             final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise =
                     new DefaultPromise(channel.eventLoop());

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ClientBusyException.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ClientBusyException.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns;
+
+/**
+ * An exception thrown to indicate that a notification could not be sent because the client was busy. This is intended
+ * to signal backpressure from the channel associated with this client
+ *
+ * @author <a href="https://github.com/stepheno">Oskar Stephens</a>
+ *
+ * @since 0.8.2
+ */
+public class ClientBusyException extends IllegalStateException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with no message.
+     */
+    public ClientBusyException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the given message.
+     *
+     * @param message a short, human-readable explanation of the cause of this exception
+     */
+    public ClientBusyException(final String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
We've increased the write buffer size enough that we are probably safe here regardless, but it's better to explicitly check the writability of the channel before accepting write requests.