### PR TITLE
Don't use the ref counted ssl engine

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/SslUtil.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/SslUtil.java
@@ -27,7 +27,7 @@ class SslUtil {
         if (OpenSsl.isAvailable()) {
             if (OpenSsl.isAlpnSupported()) {
                 log.info("Native SSL provider is available and supports ALPN; will use native provider.");
-                sslProvider = SslProvider.OPENSSL_REFCNT;
+                sslProvider = SslProvider.OPENSSL;
             } else {
                 log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
                 sslProvider = SslProvider.JDK;


### PR DESCRIPTION
It is marked as experimental, and this library is not properly releasing
instances of sslengine in all cases.