### PR TITLE
The attempt to give a write error to the response promise was being d…

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -187,17 +187,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
                     if (future.isSuccess()) {
                         final Http2Stream stream = ApnsClientHandler.this.connection().stream(streamId);
                         stream.setProperty(ApnsClientHandler.this.pushNotificationPropertyKey, pushNotification);
-                    } else {
-                        log.trace("Failed to write push notification on stream {}.", streamId, future.cause());
-
-                        final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise =
-                                ApnsClientHandler.this.responsePromises.get(pushNotification);
-
-                        if (responsePromise != null) {
-                            responsePromise.tryFailure(future.cause());
-                        } else {
-                            log.error("Notification write failed, but no response promise found.", future.cause());
-                        }
                     }
                 }
             });


### PR DESCRIPTION
…one in two separate listeners to the write promise. The place other than the one removed here is in ApnsClient.sendNotification.

There is also a listener added to the response promise itself inside ApnsClientHandler.write which removes the entry for the notification from the responsePromises map. So, the problem we see is that if the write promise listener in ApnsClient is executed first, it will complete the response promise, which will then trigger the removal of the response promise from the responsePromises map in ApnsClientHandler. Then the second listener on the write promise (the one we are removing) is called and when it tries to find the response promise from the map, it fails and logs errors. The listener on the write promise in ApnsClient is sufficient to propogate a write failure through to the response promise.