### PR TITLE
Add metric around how much time is spent between when a notification …

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -566,11 +566,13 @@ public class ApnsClient {
             final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise =
                     new DefaultPromise(channel.eventLoop());
 
+            final long submitTime = System.currentTimeMillis();
             channel.writeAndFlush(new PushNotificationAndResponsePromise(notification, responsePromise)).addListener(new GenericFutureListener<ChannelFuture>() {
 
                 @Override
                 public void operationComplete(final ChannelFuture future) throws Exception {
                     if (future.isSuccess()) {
+                        ApnsClient.this.handlerMetrics.recordSubmitToWriteLag(System.currentTimeMillis() - submitTime);
                         ApnsClient.this.metricsListener.handleNotificationSent(ApnsClient.this, notificationId);
                     } else {
                         responsePromise.tryFailure(future.cause());

--- a/pushy/src/main/java/com/relayrides/pushy/apns/HandlerMetrics.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/HandlerMetrics.java
@@ -2,6 +2,8 @@ package com.relayrides.pushy.apns;
 
 public interface HandlerMetrics {
 
+    void recordSubmitToWriteLag(long millis);
+
     void recordMaxConcurrentStreams(long maxConcurrentStreams);
 
     void maxStreamsHit();

--- a/pushy/src/main/java/com/relayrides/pushy/apns/NoopHandlerMetrics.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/NoopHandlerMetrics.java
@@ -1,6 +1,12 @@
 package com.relayrides.pushy.apns;
 
 public final class NoopHandlerMetrics implements HandlerMetrics {
+
+    @Override
+    public void recordSubmitToWriteLag(long millis) {
+
+    }
+
     @Override
     public void recordMaxConcurrentStreams(long maxConcurrentStreams) {
 


### PR DESCRIPTION
…is submitted for write to netty and when the write is actually finally written to the wire. If the max concurrent streams for a connection is reached, things will start queueing up inside the StreamBufferingEncoder and so this metric will help us understand how much time requests are spending in the queue.