### PR TITLE
Use round robin dns resolver for APNS connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>2.0.1.Final</version>
             </dependency>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -23,6 +23,10 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Apple appears to rely on DNS round robin load balancing for its APNS
servers, judging by the churn in the published dns records for the apns
endpoints. Use the netty provided round robin dns resolver to properly
utilize this scheme.