### PR TITLE
Fail the connection future in the event of an ssl exception

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -237,6 +237,15 @@ public class ApnsClient {
                             throw new IllegalArgumentException("Unexpected protocol: " + protocol);
                         }
                     }
+
+                    @Override
+                    protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                        if (ApnsClient.this.connectionReadyPromise != null) {
+                            ApnsClient.this.connectionReadyPromise.tryFailure(cause);
+                        }
+
+                        super.handshakeFailure(ctx, cause);
+                    }
                 });
             }
         });

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -19,6 +19,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.net.ssl.SSLHandshakeException;
 import java.io.File;
 import java.io.InputStream;
 import java.security.KeyPair;
@@ -302,6 +303,7 @@ public class ApnsClientTest {
         final Future<Void> connectFuture = cautiousClient.connect(HOST, PORT).await();
 
         assertFalse(connectFuture.isSuccess());
+        assertTrue(connectFuture.cause() instanceof SSLHandshakeException);
 
         cautiousClient.disconnect().await();
     }


### PR DESCRIPTION
Previous method of failure on the channel close listener masked the
cause of the failure.