### PR TITLE
Netty stream handling

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -170,15 +170,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         final ChannelPromise writePromise = context.channel().newPromise();
         this.writePushNotification(context, pushNotification, responsePromise, writePromise);
-
-        writePromise.addListener(new GenericFutureListener<Future<Void>>() {
-            @Override
-            public void operationComplete(final Future<Void> writeFuture) throws Exception {
-                if (!writeFuture.isSuccess()) {
-                    responsePromise.tryFailure(writeFuture.cause());
-                }
-            }
-        });
     }
 
     private void writePushNotification(final ChannelHandlerContext context, final ApnsPushNotification pushNotification, final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise, final ChannelPromise writePromise) {

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -44,8 +44,6 @@ import java.util.concurrent.TimeUnit;
 
 class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameListener {
 
-    private long nextStreamId = 1;
-
     private final Http2Connection.PropertyKey pushNotificationPropertyKey;
     private final Http2Connection.PropertyKey headersPropertyKey;
 
@@ -64,8 +62,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
     private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
-
-    private static final long STREAM_ID_RESET_THRESHOLD = Integer.MAX_VALUE - 1;
 
     private static final int INITIAL_PAYLOAD_BUFFER_CAPACITY = 4096;
 
@@ -173,50 +169,49 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
                 this.write(context, pushNotification, writePromise);
             }
         } else if (message instanceof ApnsPushNotification) {
-            final ApnsPushNotification pushNotification = (ApnsPushNotification) message;
+            final int streamId = this.connection().local().incrementAndGetNextStreamId();
 
-            final int streamId = (int) this.nextStreamId;
-
-            final Http2Headers headers = getHeadersForPushNotification(pushNotification, streamId);
-
-            if (!connection().local().canOpenStream()) {
-                metrics.maxStreamsHit();
-            }
-
-            final ChannelPromise headersPromise = context.newPromise();
-            this.encoder().writeHeaders(context, streamId, headers, 0, false, headersPromise);
-            log.trace("Wrote headers on stream {}: {}", streamId, headers);
-
-            final ByteBuf payloadBuffer = context.alloc().ioBuffer(INITIAL_PAYLOAD_BUFFER_CAPACITY);
-            payloadBuffer.writeBytes(pushNotification.getPayload().getBytes(StandardCharsets.UTF_8));
-
-            final ChannelPromise dataPromise = context.newPromise();
-            this.encoder().writeData(context, streamId, payloadBuffer, 0, true, dataPromise);
-            log.trace("Wrote payload on stream {}: {}", streamId, pushNotification.getPayload());
-
-            final PromiseCombiner promiseCombiner = new PromiseCombiner();
-            promiseCombiner.addAll((ChannelFuture) headersPromise, dataPromise);
-            promiseCombiner.finish(writePromise);
-
-            writePromise.addListener(new GenericFutureListener<ChannelPromise>() {
-
-                @Override
-                public void operationComplete(final ChannelPromise future) throws Exception {
-                    if (future.isSuccess()) {
-                        final Http2Stream stream = ApnsClientHandler.this.connection().stream(streamId);
-                        stream.setProperty(ApnsClientHandler.this.pushNotificationPropertyKey, pushNotification);
-                    }
-                }
-            });
-
-            this.nextStreamId += 2;
-
-            if (this.nextStreamId >= STREAM_ID_RESET_THRESHOLD) {
+            if (streamId < 0) {
                 // This is very unlikely, but in the event that we run out of stream IDs (the maximum allowed is
                 // 2^31, per https://httpwg.github.io/specs/rfc7540.html#StreamIdentifiers), we need to open a new
                 // connection. Just closing the context should be enough; automatic reconnection should take things
                 // from there.
-                context.close();
+                writePromise.tryFailure(new ClientNotConnectedException("HTTP/2 streams exhausted; closing connection."));
+                context.channel().close();
+            } else {
+
+                final ApnsPushNotification pushNotification = (ApnsPushNotification) message;
+                final Http2Headers headers = getHeadersForPushNotification(pushNotification, streamId);
+
+                if (!connection().local().canOpenStream()) {
+                    metrics.maxStreamsHit();
+                }
+
+                final ChannelPromise headersPromise = context.newPromise();
+                this.encoder().writeHeaders(context, streamId, headers, 0, false, headersPromise);
+                log.trace("Wrote headers on stream {}: {}", streamId, headers);
+
+
+                final ByteBuf payloadBuffer = context.alloc().ioBuffer(INITIAL_PAYLOAD_BUFFER_CAPACITY);
+                payloadBuffer.writeBytes(pushNotification.getPayload().getBytes(StandardCharsets.UTF_8));
+
+                final ChannelPromise dataPromise = context.newPromise();
+                this.encoder().writeData(context, streamId, payloadBuffer, 0, true, dataPromise);
+                log.trace("Wrote payload on stream {}: {}", streamId, pushNotification.getPayload());
+
+                final PromiseCombiner promiseCombiner = new PromiseCombiner();
+                promiseCombiner.addAll((ChannelFuture) headersPromise, dataPromise);
+                promiseCombiner.finish(writePromise);
+
+                writePromise.addListener(new GenericFutureListener<ChannelPromise>() {
+                    @Override
+                    public void operationComplete(final ChannelPromise future) throws Exception {
+                        if (future.isSuccess()) {
+                            final Http2Stream stream = ApnsClientHandler.this.connection().stream(streamId);
+                            stream.setProperty(ApnsClientHandler.this.pushNotificationPropertyKey, pushNotification);
+                        }
+                    }
+                });
             }
         } else {
             // This should never happen, but in case some foreign debris winds up in the pipeline, just pass it through.

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsServerException.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsServerException.java
@@ -12,6 +12,12 @@ public class ApnsServerException extends Exception {
 
     /**
      * Constructs a new APNs server exception.
+     */
+    public ApnsServerException() {
+    }
+
+    /**
+     * Constructs a new APNs server exception.
      *
      * @param message a message from the server (if any) explaining the error; may be {@code null}
      */

--- a/pushy/src/main/java/com/relayrides/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -88,7 +88,7 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
 
             // Once we've invalidated an expired token, it's reasonable to expect that re-sending the notification might
             // succeed.
-            context.channel().write(pushNotification);
+            this.retryPushNotificationFromStream(context, streamId);
         } else {
             super.handleErrorResponse(context, streamId, headers, pushNotification, errorResponse);
         }


### PR DESCRIPTION
Adapted from upstream 
* https://github.com/relayrides/pushy/pull/486
* https://github.com/relayrides/pushy/pull/485
* https://github.com/relayrides/pushy/pull/484

Use netty's abstractions on top of http2 stream handling, instead of a hand rolled implementation.

More gracefully handles a http2 stream RST, retrying outstanding messages on a new stream.