### PR TITLE
Add response timeout after write completes

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -99,6 +99,7 @@ public class ApnsClient {
 
     private Long gracefulShutdownTimeoutMillis;
     long idlePingIntervalMillis = DEFAULT_PING_IDLE_TIME_MILLIS;
+    private long responseTimeoutMillis = DEFAULT_RESPONSE_TIMEOUT_MILLIS;
 
     private volatile ChannelPromise connectionReadyPromise;
     private volatile ChannelPromise reconnectionPromise;
@@ -149,6 +150,7 @@ public class ApnsClient {
      * @since 0.10
      */
     public static final int DEFAULT_PING_IDLE_TIME_MILLIS = 60_000;
+    public static final int DEFAULT_RESPONSE_TIMEOUT_MILLIS = 30_000;
 
     private static final ClientNotConnectedException NOT_CONNECTED_EXCEPTION = new ClientNotConnectedException();
     private static final ClientBusyException CLIENT_BUSY_EXCEPTION = new ClientBusyException();
@@ -207,12 +209,14 @@ public class ApnsClient {
                                         .signingKey(ApnsClient.this.signingKey)
                                         .authority(authority)
                                         .idlePingIntervalMillis(ApnsClient.this.idlePingIntervalMillis)
+                                        .responseTimeoutMillis(ApnsClient.this.responseTimeoutMillis)
                                         .setHandlerMetrics(handlerMetrics)
                                         .build();
                             } else {
                                 apnsClientHandler = new ApnsClientHandler.ApnsClientHandlerBuilder()
                                         .authority(authority)
                                         .idlePingIntervalMillis(ApnsClient.this.idlePingIntervalMillis)
+                                        .responseTimeoutMillis(ApnsClient.this.responseTimeoutMillis)
                                         .setHandlerMetrics(handlerMetrics)
                                         .build();
                             }
@@ -306,6 +310,20 @@ public class ApnsClient {
     protected void setPingInterval(final long pingIntervalMillis) {
         this.idlePingIntervalMillis = pingIntervalMillis;
     }
+
+    /**
+     * Sets the amount of time (in milliseconds) to wait on a response from APNS before marking a notification as failed
+     * with a TimeoutException
+     *
+     * @param responseTimeoutMillis the amount of time in milliseconds after a notification write before the response
+     *                              future is marked as a failure
+     *
+     * @since 0.10
+     */
+    protected void setResponseTimeoutMillis(final long responseTimeoutMillis) {
+        this.responseTimeoutMillis = responseTimeoutMillis;
+    }
+
 
     /**
      * Sets the amount of time (in milliseconds) clients should wait for in-progress requests to complete before closing

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -74,6 +74,9 @@ public class ApnsClientBuilder {
     private Long idlePingInterval;
     private TimeUnit idlePingIntervalUnit;
 
+    private Long responseTimeout;
+    private TimeUnit responseTimeoutUnit;
+
     private Long gracefulShutdownTimeout;
     private TimeUnit gracefulShutdownTimeoutUnit;
 
@@ -370,6 +373,26 @@ public class ApnsClientBuilder {
         return this;
     }
 
+
+    /**
+     * Sets the amount of time (in milliseconds) to wait on a response from APNS before marking a notification as failed
+     * with a TimeoutException. By default, clients will wait
+     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_PING_IDLE_TIME_MILLIS} before marking the response as failed.
+     *
+     * @param responseTimeout the amount of time to wait for a response from APNS
+     * @param responseTimeoutUnit the time unit for the given response time
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.10
+     */
+    public ApnsClientBuilder setResponseTimeout(final long responseTimeout, final TimeUnit responseTimeoutUnit) {
+        this.responseTimeout = responseTimeout;
+        this.responseTimeoutUnit = responseTimeoutUnit;
+
+        return this;
+    }
+
     /**
      * Sets the amount of time clients should wait for in-progress requests to complete before closing a connection
      * during a graceful shutdown.
@@ -500,6 +523,10 @@ public class ApnsClientBuilder {
 
         if (this.idlePingInterval != null) {
             apnsClient.setPingInterval(this.idlePingIntervalUnit.toMillis(this.idlePingInterval));
+        }
+
+        if (this.responseTimeout != null) {
+            apnsClient.setResponseTimeoutMillis(this.responseTimeoutUnit.toMillis(this.responseTimeout));
         }
 
         if (this.gracefulShutdownTimeout != null) {

--- a/pushy/src/main/java/com/relayrides/pushy/apns/TokenAuthenticationApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/TokenAuthenticationApnsClientHandler.java
@@ -46,14 +46,19 @@ class TokenAuthenticationApnsClientHandler extends ApnsClientHandler {
             Objects.requireNonNull(this.authority(), "Authority must be set before building a TokenAuthenticationApnsClientHandler.");
             Objects.requireNonNull(this.signingKey(), "Signing key must be set before building a TokenAuthenticationApnsClientHandler.");
 
-            final ApnsClientHandler handler = new TokenAuthenticationApnsClientHandler(decoder, encoder, initialSettings, this.authority(), this.signingKey(), this.idlePingIntervalMillis(), this.getHandlerMetrics());
+            final ApnsClientHandler handler = new TokenAuthenticationApnsClientHandler(decoder, encoder, initialSettings,
+                    this.authority(), this.signingKey(), this.idlePingIntervalMillis(), this.responseTimeoutMillis(),
+                    this.getHandlerMetrics());
             this.frameListener(handler);
             return handler;
         }
     }
 
-    protected TokenAuthenticationApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final String authority, final ApnsSigningKey signingKey, final long idlePingIntervalMillis, HandlerMetrics metrics) {
-        super(decoder, encoder, initialSettings, authority, idlePingIntervalMillis, metrics);
+    protected TokenAuthenticationApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder,
+                                                   final Http2Settings initialSettings, final String authority,
+                                                   final ApnsSigningKey signingKey, final long idlePingIntervalMillis,
+                                                   final long responseTimeoutMillis, HandlerMetrics metrics) {
+        super(decoder, encoder, initialSettings, authority, idlePingIntervalMillis, responseTimeoutMillis, metrics);
 
         Objects.requireNonNull(signingKey, "Signing key must not be null for token-based client handlers.");
         this.signingKey = signingKey;


### PR DESCRIPTION
Adds a response timeout after a notification has been successfully written to the channel. Default is 30s